### PR TITLE
Add info about buildinfo property contents

### DIFF
--- a/docs/source/operator/uploading.rst
+++ b/docs/source/operator/uploading.rst
@@ -118,15 +118,17 @@ Please continue as follows:
 
       The version string is derived from a file that should be present in the uploaded configuration. The uploaded configuration should contain the file ``BuildInfo.properties``. Adding this file is the responsibility of Frank developers. The contents of this file should look like this:
 
-      instance.version=[some_value]
-      configuration.version=[some_value]
-      configuration.timestamp=[some_value]
-      configuration.commit=[some_value]
-      configuration.pipeline=[some_value]
-      user.name=[some_value]
-      user.fullname=[some_value]
+      .. code-block:: none
+
+         instance.version=[some_value]
+         configuration.version=[some_value]
+         configuration.timestamp=[some_value]
+         configuration.commit=[some_value]
+         configuration.pipeline=[some_value]
+         user.name=[some_value]
+         user.fullname=[some_value]
       
-      Here the "configuration.version" property is especially important as this property is needed to display the version in the Frank!Conolse.
+      Here the ``configuration.version`` property is especially important as this property is needed to display the version in the Frank!Conolse.
 
 #. Go to JDBC | Execute Query.
 #. Execute the following SQL query: ``SELECT * FROM product``.

--- a/docs/source/operator/uploading.rst
+++ b/docs/source/operator/uploading.rst
@@ -116,7 +116,17 @@ Please continue as follows:
 
    .. NOTE::
 
-      The version string is derived from a file that should be present in the uploaded configuration. The uploaded configuration should contain the file ``BuildInfo.properties``. Adding this file is the responsibility of Frank developers.
+      The version string is derived from a file that should be present in the uploaded configuration. The uploaded configuration should contain the file ``BuildInfo.properties``. Adding this file is the responsibility of Frank developers. The contents of this file should look like this:
+
+      instance.version=[some_value]
+      configuration.version=[some_value]
+      configuration.timestamp=[some_value]
+      configuration.commit=[some_value]
+      configuration.pipeline=[some_value]
+      user.name=[some_value]
+      user.fullname=[some_value]
+      
+      Here the "configuration.version" property is especially important as this property is needed to display the version in the Frank!Conolse.
 
 #. Go to JDBC | Execute Query.
 #. Execute the following SQL query: ``SELECT * FROM product``.


### PR DESCRIPTION
There was an issue on the frank!framework about missing config versions in the Frank!Console. That was because of a missing BuildInfo.properties file. There was already a reference to the file in the Frank-manual, but i wanted to add an example of the contents and highlight that the "configuration.version" property is important for the config version display in the Frank!Console.